### PR TITLE
Changed relative file to absolute file

### DIFF
--- a/plugin/vim-markdown-preview.vim
+++ b/plugin/vim-markdown-preview.vim
@@ -4,7 +4,7 @@
 "============================================================
 
 function! Vim_Markdown_Preview()
-  let curr_file = expand('%:t')
+  let curr_file = expand('%:p')
   call system('markdown ' . curr_file . ' > /tmp/vim-markdown-preview.html')
   let chrome_wid = system("xdotool search --name 'vim-markdown-preview.html - Google Chrome'")
   if !chrome_wid


### PR DESCRIPTION
Using relative files (%:t) causes a failure on generation if you open a file within vim that is not in your current working directory. This can lead to unexpected results if there is an file name identical to the one you are editing in the working directory (it will render the cwd file, not the one you are editing), or no markdown will be generated if there is no file with that name in the working directory.