### PR TITLE
Supports global variable to set a browser

### DIFF
--- a/plugin/vim-markdown-preview.vim
+++ b/plugin/vim-markdown-preview.vim
@@ -4,7 +4,7 @@
 "============================================================
 
 let b:REMOVE_TEMP_FILE = 0  "To remove the temp file, set to 1
-let b:vim_markdown_preview_browser = 'Google Chrome'
+let b:vim_markdown_preview_browser = get(g:, 'vim_markdown_preview_browser', 'Google Chrome')
 
 function! Vim_Markdown_Preview()
 


### PR DESCRIPTION
Hi again,

the changes are minimal. You don't need to modify your vim config anyhow)) Google Chrome is used by default, but the commit allows to set another browser via global varoable from user vim config. As I mentioned, this is useful for vim plugin managers, such as Vundle. I can install your plugin just by adding into .vimrc the line: `Plugin JamshedVesuna/vim-markdown-preview`, and update all my plugins via vim command PluginUpdate. So, if I change the plugin (to set up another browser) directly after installation, it will be uncapable to automatically update, because of git conflict. So using the global variable it is the way. Thanks.