### PR TITLE
Added quoting to osascript command lines

### DIFF
--- a/plugin/vim-markdown-preview.vim
+++ b/plugin/vim-markdown-preview.vim
@@ -77,11 +77,11 @@ function! Vim_Markdown_Preview()
 
   if g:vmp_osname == 'mac'
     if g:vim_markdown_preview_browser == "Google Chrome"
-      let b:vmp_preview_in_browser = system('osascript ' . g:vmp_search_script)
+      let b:vmp_preview_in_browser = system('osascript "' . g:vmp_search_script . '"')
       if b:vmp_preview_in_browser == 1
         call system('open -g /tmp/vim-markdown-preview.html')
       else
-        call system('osascript ' . g:vmp_activate_script)
+        call system('osascript "' . g:vmp_activate_script . '"')
       endif
     else
       call system('open -g /tmp/vim-markdown-preview.html')


### PR DESCRIPTION
If your .vim directory happens to be symlinked to a directory that has
spaces in its name, the system() commands that execute osascript will
fail. This PR adds quoting to those commands.