### PR TITLE
Add firefox support.

### DIFF
--- a/plugin/vim-markdown-preview.vim
+++ b/plugin/vim-markdown-preview.vim
@@ -69,13 +69,21 @@ function! Vim_Markdown_Preview()
     call system('pandoc --smart --standalone "' . b:curr_file . '" > /tmp/vim-markdown-preview.html')
   else
     call system('markdown "' . b:curr_file . '" > /tmp/vim-markdown-preview.html')
+    if g:vim_markdown_preview_browser == 'firefox'
+      " prepend html title, allowing xdotool to find the browser when updating
+      call system('echo -e "<title>vim-markdown-preview.html</title>\n$(cat /tmp/vim-markdown-preview.html)" > /tmp/vim-markdown-preview.html')
+    endif
   endif
   if v:shell_error
     echo 'Please install the necessary requirements: https://github.com/JamshedVesuna/vim-markdown-preview#requirements'
   endif
 
   if g:vmp_osname == 'unix'
-    let chrome_wid = system("xdotool search --name 'vim-markdown-preview.html - " . g:vim_markdown_preview_browser . "'")
+    if g:vim_markdown_preview_browser == 'firefox'
+      let chrome_wid = system("xdotool search --name 'vim-markdown-preview.html'")
+    else
+      let chrome_wid = system("xdotool search --name 'vim-markdown-preview.html - " . g:vim_markdown_preview_browser . "'")
+    endif
     if !chrome_wid
       if g:vim_markdown_preview_use_xdg_open == 1
         call system('xdg-open /tmp/vim-markdown-preview.html 1>/dev/null 2>/dev/null &')

--- a/plugin/vim-markdown-preview.vim
+++ b/plugin/vim-markdown-preview.vim
@@ -80,11 +80,11 @@ function! Vim_Markdown_Preview()
 
   if g:vmp_osname == 'unix'
     if g:vim_markdown_preview_browser == 'firefox'
-      let chrome_wid = system("xdotool search --name 'vim-markdown-preview.html'")
+      let browser_wid = system("xdotool search --name 'vim-markdown-preview.html'")
     else
-      let chrome_wid = system("xdotool search --name 'vim-markdown-preview.html - " . g:vim_markdown_preview_browser . "'")
+      let browser_wid = system("xdotool search --name 'vim-markdown-preview.html - " . g:vim_markdown_preview_browser . "'")
     endif
-    if !chrome_wid
+    if !browser_wid
       if g:vim_markdown_preview_use_xdg_open == 1
         call system('xdg-open /tmp/vim-markdown-preview.html 1>/dev/null 2>/dev/null &')
       else
@@ -92,8 +92,8 @@ function! Vim_Markdown_Preview()
       endif
     else
       let curr_wid = system('xdotool getwindowfocus')
-      call system('xdotool windowmap ' . chrome_wid)
-      call system('xdotool windowactivate ' . chrome_wid)
+      call system('xdotool windowmap ' . browser_wid)
+      call system('xdotool windowactivate ' . browser_wid)
       call system("xdotool key 'ctrl+r'")
       call system('xdotool windowactivate ' . curr_wid)
     endif


### PR DESCRIPTION
When creating the html, a title is prepended. Firefox uses it to set the tab text which is again what xdotool can search for.

Remember to set `g:vim_markdown_preview_browser='firefox'` in your vimrc.