### PR TITLE
Added global variable for custom browser refresh key mapping

### DIFF
--- a/plugin/vim-markdown-preview.vim
+++ b/plugin/vim-markdown-preview.vim
@@ -58,6 +58,10 @@ if !exists("g:vim_markdown_preview_hotkey")
     let g:vim_markdown_preview_hotkey='<C-p>'
 endif
 
+if !exists("g:vim_markdown_preview_browser_fresh_key")
+    let g:vim_markdown_preview_browser_fresh_key="F5"
+endif
+
 function! Vim_Markdown_Preview()
   let b:curr_file = expand('%:p')
 
@@ -86,7 +90,7 @@ function! Vim_Markdown_Preview()
       let curr_wid = system('xdotool getwindowfocus')
       call system('xdotool windowmap ' . chrome_wid)
       call system('xdotool windowactivate ' . chrome_wid)
-      call system("xdotool key 'ctrl+r'")
+      call system("xdotool key" . g:vim_markdown_preview_browser_fresh_key)
       call system('xdotool windowactivate ' . curr_wid)
     endif
   endif
@@ -140,7 +144,7 @@ function! Vim_Markdown_Preview_Local()
       let curr_wid = system('xdotool getwindowfocus')
       call system('xdotool windowmap ' . chrome_wid)
       call system('xdotool windowactivate ' . chrome_wid)
-      call system("xdotool key 'ctrl+r'")
+      call system("xdotool key" . g:vim_markdown_preview_browser_fresh_key)
       call system('xdotool windowactivate ' . curr_wid)
     endif
   endif


### PR DESCRIPTION
Title,

I wanted a feature, it didn't exist, so here it is :)

(I used F5 as the default because afaik that's the most likely browser agnostic refresh-page key combo avaliable, although don't quote me on this)