### PR TITLE
Add header for default markdown conversion

### DIFF
--- a/plugin/vim-markdown-preview.vim
+++ b/plugin/vim-markdown-preview.vim
@@ -68,7 +68,8 @@ function! Vim_Markdown_Preview()
   elseif g:vim_markdown_preview_pandoc == 1
     call system('pandoc --standalone "' . b:curr_file . '" > /tmp/vim-markdown-preview.html')
   else
-    call system('markdown "' . b:curr_file . '" > /tmp/vim-markdown-preview.html')
+    call system('echo "<head><title>vim-markdown-preview.html</title></head>" > /tmp/vim-markdown-preview.html')
+    call system('markdown "' . b:curr_file . '" >> /tmp/vim-markdown-preview.html')
   endif
   if v:shell_error
     echo 'Please install the necessary requirements: https://github.com/JamshedVesuna/vim-markdown-preview#requirements'

--- a/plugin/vim-markdown-preview.vim
+++ b/plugin/vim-markdown-preview.vim
@@ -68,7 +68,7 @@ function! Vim_Markdown_Preview()
   elseif g:vim_markdown_preview_pandoc == 1
     call system('pandoc --standalone "' . b:curr_file . '" > /tmp/vim-markdown-preview.html')
   else
-    call system('echo "<head><title>vim-markdown-preview.html</title></head>" > /tmp/vim-markdown-preview.html')
+    call system('echo "<head><title>vim-markdown-preview.html</title><meta charset=\"utf-8\"/></head>" > /tmp/vim-markdown-preview.html')
     call system('markdown "' . b:curr_file . '" >> /tmp/vim-markdown-preview.html')
   endif
   if v:shell_error


### PR DESCRIPTION
This update adds a html header for the default markdown generation.
In the newer firefox implementations this is necessary to find the active window.

The parameter WM_NAME(STRING) is empty if no title is set in the header.