### PR TITLE
Don't assume Google Chrome is the default browser

### DIFF
--- a/plugin/vim-markdown-preview.vim
+++ b/plugin/vim-markdown-preview.vim
@@ -95,7 +95,7 @@ function! Vim_Markdown_Preview()
     if g:vim_markdown_preview_browser == "Google Chrome"
       let b:vmp_preview_in_browser = system('osascript "' . g:vmp_search_script . '"')
       if b:vmp_preview_in_browser == 1
-        call system('open -g /tmp/vim-markdown-preview.html')
+        call system('open -a "' . g:vim_markdown_preview_browser . '" -g vim-markdown-preview.html')
       else
         call system('osascript "' . g:vmp_activate_script . '"')
       endif
@@ -149,7 +149,7 @@ function! Vim_Markdown_Preview_Local()
     if g:vim_markdown_preview_browser == "Google Chrome"
       let b:vmp_preview_in_browser = system('osascript "' . g:vmp_search_script . '"')
       if b:vmp_preview_in_browser == 1
-        call system('open -g vim-markdown-preview.html')
+        call system('open -a "' . g:vim_markdown_preview_browser . '" -g vim-markdown-preview.html')
       else
         call system('osascript "' . g:vmp_activate_script . '"')
       endif

--- a/plugin/vim-markdown-preview.vim
+++ b/plugin/vim-markdown-preview.vim
@@ -95,7 +95,7 @@ function! Vim_Markdown_Preview()
     if g:vim_markdown_preview_browser == "Google Chrome"
       let b:vmp_preview_in_browser = system('osascript "' . g:vmp_search_script . '"')
       if b:vmp_preview_in_browser == 1
-        call system('open -a "' . g:vim_markdown_preview_browser . '" -g vim-markdown-preview.html')
+        call system('open -a "' . g:vim_markdown_preview_browser . '" -g /tmp/vim-markdown-preview.html')
       else
         call system('osascript "' . g:vmp_activate_script . '"')
       endif


### PR DESCRIPTION
Without using `-a <browser>`, the `open` command just uses the user's
default browser. This may not be the case, and if it's not, it breaks
the preview workflow when `g:vim_markdown_preview_browser="Google Chrome"` is set.

For example, say the user's default browser is set to Firefox. If the user's vimrc has  `g:vim_markdown_preview_browser="Google Chrome"` set, the included applescripts will search Chrome for an already-open preview tab. If it doesn't find one, it'll open the preview in Firefox instead.