### PR TITLE
Add option vim_markdown_preview_pandoc_css

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Vim Markdown Preview
     - [Github Flavoured Markdown](#github)
     - [Markdown.pl](#perl)
     - [Pandoc](#pandoc)
+    - [Pandoc CSS](#pandoc_css)
     - [Use xdg-open](#xdg)
 - [Behind the Scenes](#behind-the-scenes)
 
@@ -162,6 +163,17 @@ Default: `0`
 Example: Use Pandoc to render HTML.
 ```vim
 let vim_markdown_preview_pandoc=1
+```
+
+<a name='pandoc_css'></a>
+### The `vim_markdown_preview_pandoc_css` option
+If you use pandoc to render HTML, you can specify a CSS file with this option.
+
+Default: `''`
+
+Example: Specify a CSS file for HTML.
+```vim
+let vim_markdown_preview_pandoc_css='/absolute/path/to/file.css'
 ```
 
 <a name='xdg'></a>

--- a/plugin/vim-markdown-preview.vim
+++ b/plugin/vim-markdown-preview.vim
@@ -50,6 +50,10 @@ if !exists("g:vim_markdown_preview_pandoc")
   let g:vim_markdown_preview_pandoc = 0
 endif
 
+if !exists("g:vim_markdown_preview_pandoc_css")
+  let g:vim_markdown_preview_pandoc_css = ''
+endif
+
 if !exists("g:vim_markdown_preview_use_xdg_open")
     let g:vim_markdown_preview_use_xdg_open = 0
 endif
@@ -65,8 +69,10 @@ function! Vim_Markdown_Preview()
     call system('grip "' . b:curr_file . '" --export /tmp/vim-markdown-preview.html --title vim-markdown-preview.html')
   elseif g:vim_markdown_preview_perl == 1
     call system('Markdown.pl "' . b:curr_file . '" > /tmp/vim-markdown-preview.html')
-  elseif g:vim_markdown_preview_pandoc == 1
+  elseif g:vim_markdown_preview_pandoc == 1 && g:vim_markdown_preview_pandoc_css == ''
     call system('pandoc --standalone "' . b:curr_file . '" > /tmp/vim-markdown-preview.html')
+  elseif g:vim_markdown_preview_pandoc == 1
+    call system('pandoc --standalone -c "' . g:vim_markdown_preview_pandoc_css . '" "' . b:curr_file . '" > /tmp/vim-markdown-preview.html')
   else
     call system('markdown "' . b:curr_file . '" > /tmp/vim-markdown-preview.html')
   endif
@@ -119,8 +125,10 @@ function! Vim_Markdown_Preview_Local()
     call system('grip "' . b:curr_file . '" --export vim-markdown-preview.html --title vim-markdown-preview.html')
   elseif g:vim_markdown_preview_perl == 1
     call system('Markdown.pl "' . b:curr_file . '" > /tmp/vim-markdown-preview.html')
-  elseif g:vim_markdown_preview_pandoc == 1
+  elseif g:vim_markdown_preview_pandoc == 1 && g:vim_markdown_preview_pandoc_css == ''
     call system('pandoc --standalone "' . b:curr_file . '" > /tmp/vim-markdown-preview.html')
+  elseif g:vim_markdown_preview_pandoc == 1
+    call system('pandoc --standalone -c "' . g:vim_markdown_preview_pandoc_css . '" "' . b:curr_file . '" > /tmp/vim-markdown-preview.html')
   else
     call system('markdown "' . b:curr_file . '" > vim-markdown-preview.html')
   endif


### PR DESCRIPTION
Add an option to specify a css file for genration with pandoc. In the vimrc :
let vim_markdown_preview_pandoc_css='/absolute/path/to/file.css'
or
let vim_markdown_preview_pandoc_css='$HOME/path/to/file.css'

You can test with this css : https://gist.github.com/Dashed/6714393