### PR TITLE
handle multiple multiple windows matching search name

### DIFF
--- a/plugin/vim-markdown-preview.vim
+++ b/plugin/vim-markdown-preview.vim
@@ -75,7 +75,7 @@ function! Vim_Markdown_Preview()
   endif
 
   if g:vmp_osname == 'unix'
-    let chrome_wid = system("xdotool search --name 'vim-markdown-preview.html - " . g:vim_markdown_preview_browser . "'")
+    let chrome_wid = system("xdotool search --name 'vim-markdown-preview.html - " . g:vim_markdown_preview_browser . "' | sort | tail -n 1")
     if !chrome_wid
       if g:vim_markdown_preview_use_xdg_open == 1
         call system('xdg-open /tmp/vim-markdown-preview.html 1>/dev/null 2>/dev/null &')


### PR DESCRIPTION
Similar to https://github.com/JamshedVesuna/vim-markdown-preview/issues/84, Mozilla Firefox 68.0.1
on Ubuntu 18.04 would always open in a new tab. The line referenced in this PR would occasionally return two window IDs, causing the subsequent lines to fail.

This fix simply gets the highest value window ID returned by `xdotool search ...` and uses it for switching.